### PR TITLE
added pre-condition check before performing submit

### DIFF
--- a/egasub/submission/submittable/base.py
+++ b/egasub/submission/submittable/base.py
@@ -149,7 +149,7 @@ class Submittable(object):
                         pass # alias has changed, this should never happen, if it does, we simply ignore and do not restore the status
                     else:  # never restore object id, which should always be taken from the server side
                         obj.alias = alias
-                        # obj.status = status  # we shouldn't need to restore status either, should get it from the server
+                        obj.status = status  # we need to get status at last operation with EGA, it will be used to decide whether it's ready for performing submission
         except:
             pass  # do nothing on error
 


### PR DESCRIPTION
This is a good solution to a problem we ran into while testing. The scenario was that experiment and run were submitted one by one, due to missing files on the upload area, it ended up with experiment 'SUBMITTED' but run 'VALIDATED_WITH_ERROR'. The problem was that even after files were in place, submitting the previously errored out run still ended up failing. This is likely an issue on the EGA API side, but from our point view, let's not to proceed with 'submit' until all objects (particularly for experiment and run objects) are VALIDATED. This pre-condition check is now implemented.